### PR TITLE
Add NTS Radio

### DIFF
--- a/NTSRadio.bsstrategy
+++ b/NTSRadio.bsstrategy
@@ -1,0 +1,51 @@
+//
+//  NTS Radio
+//  BeardedSpice
+//
+//
+//  Created by Grant Levene on 07/08/20
+//  Copyright (c) 2020 Tyler Rhodes / Jose Falcon. All rights reserved.
+//
+
+BSStrategy = {
+    version: 1,
+    displayName: "NTS Radio",
+    accepts: {
+        method: "predicateOnTab",
+        format: "%K LIKE[c] '*www.nts.live*'",
+        args: ["URL"]
+    },
+    pause: function() {
+        const mixcloudContent = document.getElementById("mixcloud-content");
+
+        if (mixcloudContent) {
+            const widget = window.Mixcloud.PlayerWidget(mixcloudContent);
+            widget.ready.then(function() {
+                widget.pause();
+            });
+        }
+
+        document.dispatchEvent(new CustomEvent("ntsStopRadio"));
+    },
+    toggle: function() {
+        const mixcloudContent = document.getElementById("mixcloud-content");
+        const radioPlayer = document.querySelector("audio");
+
+        if (mixcloudContent) {
+            const widget = window.Mixcloud.PlayerWidget(mixcloudContent);
+            widget.ready.then(function() {
+                widget.togglePlay();
+            });
+
+            return;
+        }
+
+        if (radioPlayer) {
+            if (radioPlayer.paused) {
+                radioPlayer.play();
+            } else {
+                radioPlayer.pause();
+            }
+        }
+    }
+};


### PR DESCRIPTION
Add support for play / pause / toggle on NTS Radio's website
(https://nts.live).

Note: When listening to audio from NTS.live, it's from one of two
sources:

    * An <audio> element
    * An <iframe> with a Mixcloud widget inside.

The first source is easy enough to work with, but the mixcloud one is
not. While Mixcloud does provide an API to interact with it, it's
entirely asynchronous. This is fine for playing / pausing, but if we
want to retrieve any information from it, further hacks / support will
need to be implemented.